### PR TITLE
Auto discovery of arylic devices on the network

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "1.9.22"
-    kotlin("plugin.allopen") version "1.9.22"
-    kotlin("plugin.serialization") version "1.9.22"
+    kotlin("jvm") version "1.9.23"
+    kotlin("plugin.allopen") version "1.9.23"
+    kotlin("plugin.serialization") version "1.9.23"
     id("io.quarkus")
     id("distribution")
 }
@@ -20,22 +20,20 @@ dependencies {
     implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
     implementation("io.quarkus:quarkus-smallrye-reactive-messaging-mqtt")
     implementation("io.quarkus:quarkus-kotlin")
-    implementation("io.quarkus:quarkus-resteasy-reactive-kotlin-serialization")
+    implementation("io.quarkus:quarkus-rest-jackson")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("io.quarkus:quarkus-arc")
-    implementation("io.quarkus:quarkus-resteasy-reactive")
+    implementation("io.quarkus:quarkus-rest")
     implementation("io.quarkus:quarkus-jackson")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.github.oshai:kotlin-logging-jvm:6.0.9")
-    implementation("io.quarkus:quarkus-smallrye-reactive-messaging-mqtt")
     implementation("xyz.gianlu.zeroconf:zeroconf:1.3.2")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.rest-assured:rest-assured")
-    //testImplementation("io.kotest:kotest-runner-junit5-jvm:5.6.+")
-    testImplementation("io.kotest:kotest-assertions-core:5.6.+")
+    testImplementation("io.kotest:kotest-assertions-core:5.8.+")
     testImplementation("io.quarkiverse.mockk:quarkus-junit5-mockk:2.1.0")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,14 @@
 plugins {
     kotlin("jvm") version "1.9.22"
     kotlin("plugin.allopen") version "1.9.22"
+    kotlin("plugin.serialization") version "1.9.22"
     id("io.quarkus")
     id("distribution")
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
 }
 
 val quarkusPlatformGroupId: String by project
@@ -26,13 +27,16 @@ dependencies {
     implementation("io.quarkus:quarkus-resteasy-reactive")
     implementation("io.quarkus:quarkus-jackson")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("io.github.oshai:kotlin-logging-jvm:5.0.0")
+    implementation("io.github.oshai:kotlin-logging-jvm:6.0.9")
     implementation("io.quarkus:quarkus-smallrye-reactive-messaging-mqtt")
+    implementation("xyz.gianlu.zeroconf:zeroconf:1.3.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.rest-assured:rest-assured")
     //testImplementation("io.kotest:kotest-runner-junit5-jvm:5.6.+")
     testImplementation("io.kotest:kotest-assertions-core:5.6.+")
+    testImplementation("io.quarkiverse.mockk:quarkus-junit5-mockk:2.1.0")
 }
 
 group = "org.acme"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
-quarkusPluginVersion=3.6.4
+quarkusPluginVersion=3.9.4
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPluginId=io.quarkus
 quarkusPlatformGroupId=io.quarkus.platform
-quarkusPlatformVersion=3.6.4
+quarkusPlatformVersion=3.9.4

--- a/src/main/kotlin/org/acme/ArylicConfig.kt
+++ b/src/main/kotlin/org/acme/ArylicConfig.kt
@@ -10,12 +10,17 @@ interface ArylicConfig {
 
     fun discoveryTimer(): java.time.Duration
     fun pingTimer(): java.time.Duration
+    fun autoDiscovery(): AutoDiscovery
 
     interface Device {
         //fun name(): String
         fun ip(): String
 
         fun port(): Optional<Int>
+    }
+
+    interface AutoDiscovery {
+        fun enabled(): Optional<Boolean>
     }
 
 }

--- a/src/main/kotlin/org/acme/ArylicResource.kt
+++ b/src/main/kotlin/org/acme/ArylicResource.kt
@@ -7,7 +7,6 @@ import io.vertx.core.Future
 import jakarta.inject.Inject
 import jakarta.ws.rs.*
 import jakarta.ws.rs.core.MediaType
-import kotlinx.serialization.Serializable
 
 @Path("/arylic/{device}")
 class ArylicResource {
@@ -21,7 +20,6 @@ class ArylicResource {
         return controller.getConnection(device) ?: throw NotFoundException("Device with name $device not found")
     }
 
-    @Serializable
     data class Muted(val device: String, val muted: Boolean)
 
     @GET
@@ -77,7 +75,6 @@ class ArylicResource {
         return UniHelper.toUni(fut)
     }
 
-    @Serializable
     data class PlayStatusRest(val device: String, val playing: Boolean)
 
     @GET

--- a/src/main/kotlin/org/acme/ArylicResource.kt
+++ b/src/main/kotlin/org/acme/ArylicResource.kt
@@ -1,12 +1,13 @@
 package org.acme
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.vertx.UniHelper
 import io.vertx.core.Future
 import jakarta.inject.Inject
 import jakarta.ws.rs.*
 import jakarta.ws.rs.core.MediaType
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
+import kotlinx.serialization.Serializable
 
 @Path("/arylic/{device}")
 class ArylicResource {
@@ -20,103 +21,96 @@ class ArylicResource {
         return controller.getConnection(device) ?: throw NotFoundException("Device with name $device not found")
     }
 
+    @Serializable
+    data class Muted(val device: String, val muted: Boolean)
+
     @GET
     @Path("mute")
-    @Produces(MediaType.TEXT_PLAIN)
-    fun mute(@PathParam("device") device: String): String {
+    @Produces(MediaType.APPLICATION_JSON)
+    fun mute(@PathParam("device") device: String): Muted {
         log.info { "mute" }
         getDevice(device).sendCommand(Command.Mute(true))
-        return "$device muted\n"
+        return Muted(device, true)
     }
 
     @GET
     @Path("unmute")
-    @Produces(MediaType.TEXT_PLAIN)
-    fun unmute(@PathParam("device") device: String): String {
+    @Produces(MediaType.APPLICATION_JSON)
+    fun unmute(@PathParam("device") device: String): Muted {
         log.info { "unmute" }
         getDevice(device).sendCommand(Command.Mute(false))
-        return "$device unmuted\n"
+        return Muted(device, false)
     }
 
     @GET
     @Path("device-info")
-    @Produces(MediaType.TEXT_PLAIN)
-    fun deviceInfo(@PathParam("device") device: String): CompletableFuture<Command.DeviceInfo> {
+    @Produces(MediaType.APPLICATION_JSON)
+    fun deviceInfo(@PathParam("device") device: String): Uni<Command.DeviceInfo> {
         log.info { "device-info" }
         val conn = getDevice(device)
         val fut = conn.expect(Command.DeviceInfo::class.java)
         conn.sendCommand(Command.DeviceInfoCmd)
-        return asCompletableFuture(fut)
+        return UniHelper.toUni(fut)
     }
 
     @GET
     @Path("metadata")
-    @Produces(MediaType.TEXT_PLAIN)
-    fun metadata(@PathParam("device") device: String): CompletableFuture<Command.Data> {
+    @Produces(MediaType.APPLICATION_JSON)
+    fun metadata(@PathParam("device") device: String): Uni<Command.Data> {
         log.info { "playback metadata" }
         val conn = getDevice(device)
         val fut = conn.expect(Command.Data::class.java)
         conn.sendCommand(Command.PlaybackMetadata)
 
-        return asCompletableFuture(fut)
+        return UniHelper.toUni(fut)
     }
-
 
     @GET
     @Path("status")
-    @Produces(MediaType.TEXT_PLAIN)
-    fun status(@PathParam("device") device: String): CompletableFuture<Command.PlayInfo> {
+    @Produces(MediaType.APPLICATION_JSON)
+    fun status(@PathParam("device") device: String): Uni<Command.PlayInfo> {
         log.info { "playback status" }
         val conn = getDevice(device)
         val fut = conn.expect(Command.PlayInfo::class.java)
         conn.sendCommand(Command.PlaybackStatus)
 
-        return asCompletableFuture(fut)
+        return UniHelper.toUni(fut)
     }
+
+    @Serializable
+    data class PlayStatusRest(val device: String, val playing: Boolean)
 
     @GET
     @Path("playpause")
-    @Produces(MediaType.TEXT_PLAIN)
-    fun playPause(@PathParam("device") device: String): CompletableFuture<Command.PlayStatus> {
+    @Produces(MediaType.APPLICATION_JSON)
+    fun playPause(@PathParam("device") device: String): Uni<PlayStatusRest> {
         log.info { "play/pause" }
         val conn = getDevice(device)
         val fut = conn.expect(Command.PlayStatus::class.java)
         conn.sendCommand(Command.PlayPause)
 
-        return asCompletableFuture(fut)
+        return UniHelper.toUni(fut.compose { status -> Future.succeededFuture(PlayStatusRest(device, status.playing)) })
     }
 
     @GET
     @Path("play")
-    @Produces(MediaType.TEXT_PLAIN)
-    fun play(@PathParam("device") device: String): String {
+    @Produces(MediaType.APPLICATION_JSON)
+    fun play(@PathParam("device") device: String): PlayStatusRest {
         log.info { "play" }
         val conn = getDevice(device)
         conn.sendCommand(Command.Play) //won't reply if there is no change
 
-        return "OK"
+        return PlayStatusRest(device, true)
     }
 
     @GET
     @Path("pause")
-    @Produces(MediaType.TEXT_PLAIN)
-    fun pause(@PathParam("device") device: String): String {
+    @Produces(MediaType.APPLICATION_JSON)
+    fun pause(@PathParam("device") device: String): PlayStatusRest {
         log.info { "pause" }
         val conn = getDevice(device)
         conn.sendCommand(Command.Pause)
 
-        return "OK"
-    }
-
-    private fun <T : Any> asCompletableFuture(fut: Future<T>): CompletableFuture<T> {
-        val cf = CompletableFuture<T>()
-        fut.onComplete { ar ->
-            if (ar.succeeded()) {
-                cf.complete(ar.result())
-            } else {
-                cf.completeExceptionally(ar.cause())
-            }
-        }
-        return cf.orTimeout(5, TimeUnit.SECONDS)
+        return PlayStatusRest(device, false)
     }
 }

--- a/src/main/kotlin/org/acme/ArylicResourceToplevel.kt
+++ b/src/main/kotlin/org/acme/ArylicResourceToplevel.kt
@@ -1,0 +1,35 @@
+package org.acme
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Inject
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import kotlinx.serialization.Serializable
+
+@Path("/arylic")
+class ArylicResourceToplevel {
+
+    private val log = KotlinLogging.logger {}
+
+    @Inject
+    lateinit var controller: Controller
+
+    private fun getDevice(device: String): ArylicConnection {
+        return controller.getConnection(device) ?: throw NotFoundException("Device with name $device not found")
+    }
+
+    @Serializable
+    data class DeviceRest(val id: String, val host: String)
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    fun getDevices(): List<DeviceRest> {
+        log.info { "getDevices" }
+        return controller.getConnections().map { d -> DeviceRest(d.key, d.value.device.host) }.toList()
+    }
+
+
+}

--- a/src/main/kotlin/org/acme/ArylicResourceToplevel.kt
+++ b/src/main/kotlin/org/acme/ArylicResourceToplevel.kt
@@ -7,7 +7,6 @@ import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
-import kotlinx.serialization.Serializable
 
 @Path("/arylic")
 class ArylicResourceToplevel {
@@ -21,7 +20,6 @@ class ArylicResourceToplevel {
         return controller.getConnection(device) ?: throw NotFoundException("Device with name $device not found")
     }
 
-    @Serializable
     data class DeviceRest(val id: String, val host: String)
 
     @GET

--- a/src/main/kotlin/org/acme/Command.kt
+++ b/src/main/kotlin/org/acme/Command.kt
@@ -4,6 +4,7 @@ package org.acme
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.Serializable
 
 private val log = KotlinLogging.logger {}
 
@@ -70,6 +71,7 @@ sealed interface Command {
         }
     }
 
+    @Serializable
     data class DeviceInfo(
         ////AXX+DEV+INFSoundSystem_B706;release;Bureau;;0;0;0&
         val apSsid: String,

--- a/src/main/kotlin/org/acme/Command.kt
+++ b/src/main/kotlin/org/acme/Command.kt
@@ -2,9 +2,9 @@
 
 package org.acme
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.serialization.Serializable
 
 private val log = KotlinLogging.logger {}
 
@@ -71,7 +71,6 @@ sealed interface Command {
         }
     }
 
-    @Serializable
     data class DeviceInfo(
         ////AXX+DEV+INFSoundSystem_B706;release;Bureau;;0;0;0&
         val apSsid: String,

--- a/src/main/kotlin/org/acme/Mqtt.kt
+++ b/src/main/kotlin/org/acme/Mqtt.kt
@@ -2,12 +2,15 @@ package org.acme
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.netty.handler.codec.mqtt.MqttQoS
+import io.smallrye.config.ConfigMapping
+import io.smallrye.config.WithDefault
 import io.smallrye.reactive.messaging.mqtt.MqttMessage
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
 import org.eclipse.microprofile.reactive.messaging.Incoming
+import java.util.*
 import java.util.concurrent.CompletionStage
 import java.util.regex.Pattern
 
@@ -98,4 +101,11 @@ class Mqtt {
         }
         device.sendCommand(Command.Volume(volume))
     }
+}
+
+
+@ConfigMapping(prefix = "mqtt")
+interface MqttConfig {
+    @WithDefault("true")
+    fun enabled(): Boolean
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-%dev.arylic.devices[0].ip=192.168.1.73
-%dev.arylic.devices[1].ip=192.168.1.92
-%dev.arylic.devices[2].ip=192.168.1.185
+#%dev.arylic.devices[0].ip=192.168.1.73
+#%dev.arylic.devices[1].ip=192.168.1.92
+#%dev.arylic.devices[2].ip=192.168.1.185
 #arylic.devices[1].ip=192.168.1.185
 
 #Interval at which to try to connect again if connection was broken
@@ -8,14 +8,17 @@ arylic.discovery-timer=PT30s
 #Interal at which to write an empty message to detect broken sockets
 arylic.ping-timer=PT5m
 
+quarkus.log.level=INFO
+quarkus.log.category."org.acme".level=INFO
 
+#
 mqtt.host=127.0.0.1
 mqtt.port=1883
 mqtt.client-id=arylic-mqtt
 %dev.mqtt.client-id=arylic-mqtt-dev
 
-mp.messaging.connector.smallrye-mqtt.host=${mqtt.host}
-mp.messaging.connector.smallrye-mqtt.port=${mqtt.port}
+%prod.mp.messaging.connector.smallrye-mqtt.host=${mqtt.host}
+%prod.mp.messaging.connector.smallrye-mqtt.port=${mqtt.port}
 mp.messaging.connector.smallrye-mqtt.client-id=${mqtt.client-id}
 mp.messaging.connector.smallrye-mqtt.username=${mqtt.username:}
 mp.messaging.connector.smallrye-mqtt.password=${mqtt.password:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,8 +31,8 @@ mp.messaging.connector.smallrye-mqtt.ssl.truststore.location=${mqtt.ssl.truststo
 mp.messaging.connector.smallrye-mqtt.ssl.truststore.password=${mqtt.ssl.truststore.password:}
 
 # Inbound
-mp.messaging.incoming.cmd.type=smallrye-mqtt
+mp.messaging.incoming.cmd.connector=smallrye-mqtt
 mp.messaging.incoming.cmd.topic=arylic/cmd/#
 
 # Outbound
-mp.messaging.outgoing.state.type=smallrye-mqtt
+mp.messaging.outgoing.state.connector=smallrye-mqtt

--- a/src/test/kotlin/org/acme/ControllerTest.kt
+++ b/src/test/kotlin/org/acme/ControllerTest.kt
@@ -1,21 +1,20 @@
 package org.acme
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.kotest.assertions.timing.eventually
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.netty.handler.codec.mqtt.MqttConnectPayload
-import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.TestProfile
 import jakarta.inject.Inject
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
-import java.lang.RuntimeException
-import java.net.ServerSocket
 import java.net.SocketException
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
@@ -23,7 +22,6 @@ import kotlin.time.Duration.Companion.seconds
 @OptIn(ExperimentalUnsignedTypes::class)
 @QuarkusTest
 @Timeout(value = 10, unit = TimeUnit.SECONDS)
-//@QuarkusTestResource(SocketTestResource::class)
 @TestProfile(MockSocketProfile::class)
 class ControllerTest {
     @Inject
@@ -65,12 +63,12 @@ class ControllerTest {
             log.info { "Socket connected" }
             outStream = BufferedOutputStream(socket.getOutputStream())
             inStream = BufferedInputStream(socket.getInputStream())
-            running=true
+            running = true
             try {
                 while (running) {
                     readData(inStream!!)
                 }
-            }catch (ex: SocketException) {
+            } catch (ex: SocketException) {
                 if (running) {
                     throw RuntimeException("Did not expect socket exception at this point", ex)
                 }
@@ -115,8 +113,9 @@ class ControllerTest {
         log.debug { "encoded payload: " + Helper.bytesToHex(data) }
         return data
     }
+
     fun closeSocket() {
-        running =false
+        running = false
         inStream?.close()
         outStream?.close()
         ss.close()

--- a/src/test/kotlin/org/acme/ControllerTest.kt
+++ b/src/test/kotlin/org/acme/ControllerTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldNotBe
 import io.netty.handler.codec.mqtt.MqttConnectPayload
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.TestProfile
 import jakarta.inject.Inject
 import kotlinx.coroutines.*
 import org.junit.jupiter.api.Test
@@ -22,7 +23,8 @@ import kotlin.time.Duration.Companion.seconds
 @OptIn(ExperimentalUnsignedTypes::class)
 @QuarkusTest
 @Timeout(value = 10, unit = TimeUnit.SECONDS)
-@QuarkusTestResource(SocketTestResource::class)
+//@QuarkusTestResource(SocketTestResource::class)
+@TestProfile(MockSocketProfile::class)
 class ControllerTest {
     @Inject
     lateinit var controller: Controller

--- a/src/test/kotlin/org/acme/MockSocketProfile.kt
+++ b/src/test/kotlin/org/acme/MockSocketProfile.kt
@@ -1,0 +1,43 @@
+package org.acme
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTestProfile
+
+
+class MockSocketProfile: QuarkusTestProfile {
+
+
+    /**
+     * Allows the default config profile to be overridden. This basically just sets the quarkus.test.profile system
+     * property before the test is run.
+     *
+     * Here we are setting the profile to test-mocked
+     */
+    override fun getConfigProfile(): String {
+        return "mocked-socket";
+    }
+
+    /**
+     * Additional [QuarkusTestResourceLifecycleManager] classes (along with their init params) to be used from this
+     * specific test profile.
+     *
+     * If this method is not overridden, then only the [QuarkusTestResourceLifecycleManager] classes enabled via the [io.quarkus.test.common.QuarkusTestResource] class
+     * annotation will be used for the tests using this profile (which is the same behavior as tests that don't use a profile at all).
+     */
+    override fun testResources(): List<QuarkusTestProfile.TestResourceEntry> {
+        return listOf(
+            QuarkusTestProfile.TestResourceEntry(
+                SocketTestResource::class.java
+            )
+        )
+    }
+
+
+    /**
+     * If this returns true then only the test resources returned from [.testResources] will be started,
+     * global annotated test resources will be ignored.
+     */
+    override fun disableGlobalTestResources(): Boolean {
+        return true
+    }
+}

--- a/src/test/kotlin/org/acme/ResourceTest.kt
+++ b/src/test/kotlin/org/acme/ResourceTest.kt
@@ -15,7 +15,6 @@ import jakarta.ws.rs.core.HttpHeaders
 import jakarta.ws.rs.core.MediaType
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.net.URI
@@ -104,7 +103,6 @@ class ResourceTest {
     }
 
     @Test
-    @Disabled
     fun testMetadata() {
         val data = Command.Data("title", "artist", "album", "vendor", 5)
         every { mockConnection.expect(Command.Data::class.java) } returns Future.succeededFuture(data)
@@ -112,7 +110,6 @@ class ResourceTest {
     }
 
     @Test
-    @Disabled
     fun testStatus() {
         val data = Command.PlayInfo(
             "type",

--- a/src/test/kotlin/org/acme/ResourceTest.kt
+++ b/src/test/kotlin/org/acme/ResourceTest.kt
@@ -1,0 +1,159 @@
+package org.acme
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkiverse.test.junit.mockk.InjectMock
+import io.quarkus.test.common.http.TestHTTPEndpoint
+import io.quarkus.test.common.http.TestHTTPResource
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured
+import io.vertx.core.Future
+import jakarta.inject.Inject
+import jakarta.ws.rs.core.HttpHeaders
+import jakarta.ws.rs.core.MediaType
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+
+@QuarkusTest
+@Timeout(value = 10, unit = TimeUnit.SECONDS)
+class ResourceTest {
+
+    @InjectMock
+    private lateinit var mockController: Controller
+
+    @TestHTTPEndpoint(ArylicResourceToplevel::class)
+    @TestHTTPResource
+    lateinit var urlArylicToplevel: URI
+    lateinit var urlDevice: URI
+
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+    @Inject
+    private lateinit var objectMapper: ObjectMapper
+    private val mockConnection = mockk<ArylicConnection>(relaxed = true)
+    private val deviceInfo = Command.DeviceInfo("apSsid", "type", "name", "routerSsid", 2, 4, 6)
+
+    @BeforeEach
+    fun setupMocks() {
+        urlDevice = urlArylicToplevel.resolve("arylic/device1/")
+        every { mockConnection.device } returns Device("fakehost.mock")
+        every { mockController.getConnections() } returns mapOf("device1" to mockConnection)
+        every { mockController.getConnection("device1") } returns mockConnection
+        every { mockController.getConnection("invalidDevice") } returns null
+        every { mockConnection.expect(Command.DeviceInfo::class.java) } returns Future.succeededFuture(deviceInfo)
+    }
+
+    @Test
+    fun testToplevel() {
+        log.debug { "testToplevel" }
+        val res = ArylicResourceToplevel.DeviceRest("device1", "fakehost.mock")
+        val resAsString = objectMapper.writeValueAsString(listOf(res))
+        RestAssured.given()
+            .`when`()
+            .get(urlArylicToplevel)
+            .then()
+            .statusCode(200)
+            .body(`is`(resAsString))
+    }
+
+    @Test
+    fun testInvalidDevice() {
+        RestAssured.given()
+            .`when`()
+            .get(urlArylicToplevel.resolve("arylic/invalidDevice/device-info"))
+            .then()
+            .statusCode(404)
+    }
+
+    private fun deviceOk(path: String, res: Any) {
+        val resAsString = objectMapper.writeValueAsString(res)
+        val url = urlDevice.resolve(path)
+        log.debug { "url: $url" }
+        RestAssured.given()
+            .`when`()
+            .get(url)
+            .then()
+            .statusCode(200)
+            .header(HttpHeaders.CONTENT_TYPE, "${MediaType.APPLICATION_JSON};charset=UTF-8")
+            .body(`is`(resAsString))
+    }
+
+    @Test
+    fun testDeviceInfo() {
+        deviceOk("device-info", deviceInfo)
+    }
+
+    @Test
+    fun testMute() {
+        deviceOk("mute", ArylicResource.Muted("device1", true))
+    }
+
+    @Test
+    fun testUnmute() {
+        deviceOk("unmute", ArylicResource.Muted("device1", false))
+    }
+
+    @Test
+    @Disabled
+    fun testMetadata() {
+        val data = Command.Data("title", "artist", "album", "vendor", 5)
+        every { mockConnection.expect(Command.Data::class.java) } returns Future.succeededFuture(data)
+        deviceOk("metadata", data)
+    }
+
+    @Test
+    @Disabled
+    fun testStatus() {
+        val data = Command.PlayInfo(
+            "type",
+            "ch",
+            "mode",
+            "loop",
+            "eq",
+            "status",
+            "curpos",
+            "offsetPts",
+            "totlen",
+            "title",
+            "artist",
+            "album",
+            "alarmflag",
+            "plicount",
+            "plicurr",
+            "vol",
+            "mute"
+        )
+        every { mockConnection.expect(Command.PlayInfo::class.java) } returns Future.succeededFuture(data)
+        deviceOk("status", data)
+    }
+
+    @Test
+    fun testPlaypause() {
+        val data = Command.PlayStatus(true)
+        every { mockConnection.expect(Command.PlayStatus::class.java) } returns Future.succeededFuture(data)
+        val res = ArylicResource.PlayStatusRest("device1", true)
+        deviceOk("playpause", res)
+    }
+
+    @Test
+    fun testPlay() {
+        val data = ArylicResource.PlayStatusRest("device1", true)
+        deviceOk("play", data)
+    }
+
+    @Test
+    fun testPause() {
+        val data = ArylicResource.PlayStatusRest("device1", false)
+        deviceOk("pause", data)
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+
+arylic.auto-discovery.enabled=false


### PR DESCRIPTION
Also
* Use JSON output in all the rest endpoints
* Upstep quarkus to 3.9
* More test coverage
* Added `/arylic` endpoint